### PR TITLE
Default value for options to be empty hash

### DIFF
--- a/lib/cocoapods-binary-cache/pod-binary/helper/detected_prebuilt_pods/target_definition.rb
+++ b/lib/cocoapods-binary-cache/pod-binary/helper/detected_prebuilt_pods/target_definition.rb
@@ -3,7 +3,7 @@ module Pod
     class TargetDefinition
       def detect_prebuilt_pod(name, requirements)
         @explicit_prebuilt_pod_names ||= []
-        options = requirements.last
+        options = requirements.last || {}
         if Pod::Podfile::DSL.prebuild_all?
           @explicit_prebuilt_pod_names << Specification.root_name(name)
         elsif options.is_a?(Hash) && options[:binary]


### PR DESCRIPTION
Currently there is a crash occurring for a pod omitting the `:binary` option. I believe its default value should be `false`. With the plugin enabled, the expected behavior of `pod 'MyPod'` is that it should just work like normal, no binary caching involved.  The actual crash is occurring on line `13` where it's checking if `options` is empty when it's actually `nil`. Interestingly enough, if a version string is the last requirement it will not crash since `empty?` is a method shared between strings and hashes. So this actually works: `pod 'MyPod', '~> 1.0'`. But if you remove the version string, it crashes.