### PR TITLE
Fixed: TODO: this detect objc lib as empty source, eg. Realm

### DIFF
--- a/lib/cocoapods-binary-cache/helper/podspec.rb
+++ b/lib/cocoapods-binary-cache/helper/podspec.rb
@@ -2,14 +2,9 @@ module Pod
   class Specification
     def empty_source_files?
 
-      if !subspecs.empty?
-        subspecs_empty = subspecs.all?(&:empty_source_files?)
-
-        # return early if there are some files in subpec(s)
-        # but process the spec itself
-        if !subspecs_empty
-          return false
-        end
+      unless subspecs.empty?
+        # return early if there are some files in subpec(s) but process the spec itself
+        return false unless subspecs.all?(&:empty_source_files?)
       end
 
       check = lambda do |patterns|

--- a/lib/cocoapods-binary-cache/helper/podspec.rb
+++ b/lib/cocoapods-binary-cache/helper/podspec.rb
@@ -1,8 +1,16 @@
 module Pod
   class Specification
-    # TODO: this detect objc lib as empty source, eg. Realm
     def empty_source_files?
-      return subspecs.all?(&:empty_source_files?) unless subspecs.empty?
+
+      if !subspecs.empty?
+        subspecs_empty = subspecs.all?(&:empty_source_files?)
+
+        # return early if there are some files in subpec(s)
+        # but process the spec itself
+        if !subspecs_empty
+          return false
+        end
+      end
 
       check = lambda do |patterns|
         patterns = [patterns] if patterns.is_a?(String)

--- a/spec/helper/podspec_spec.rb
+++ b/spec/helper/podspec_spec.rb
@@ -64,11 +64,20 @@ describe "Specification" do
         expect(spec.empty_source_files?).to be false
       end
 
-      it "returns false if all subspec have empty source files, but the parent spec has" do
+      it "returns false if all subspecs have empty source files, but the parent spec has" do
         spec = Pod::Specification.new do |s|
           s.source_files = ["path/to/*.cpp"]
           s.subspec("A") { |ss| ss.source_files = [] }
           s.subspec("B") { |ss| ss.source_files = [] }
+        end
+        expect(spec.empty_source_files?).to be false
+      end
+
+      it "returns false if a subspec and the spec itself have source files" do
+        spec = Pod::Specification.new do |s|
+          s.source_files = ["path/to/*.cpp"]
+          s.subspec("A") { |ss| ss.source_files = [] }
+          s.subspec("B") { |ss| ss.source_files = ["path/to/*.swift"] }
         end
         expect(spec.empty_source_files?).to be false
       end

--- a/spec/helper/podspec_spec.rb
+++ b/spec/helper/podspec_spec.rb
@@ -63,6 +63,15 @@ describe "Specification" do
         end
         expect(spec.empty_source_files?).to be false
       end
+
+      it "returns false if all subspec have empty source files, but the parent spec has" do
+        spec = Pod::Specification.new do |s|
+          s.source_files = ["path/to/*.cpp"]
+          s.subspec("A") { |ss| ss.source_files = [] }
+          s.subspec("B") { |ss| ss.source_files = [] }
+        end
+        expect(spec.empty_source_files?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
Check if the spec itself has source_files even if its subspecs don't