### PR TITLE
chore(*): provide an option to still download sources for prebuilt frameworks

### DIFF
--- a/docs/configure_cocoapods_binary_cache.md
+++ b/docs/configure_cocoapods_binary_cache.md
@@ -42,6 +42,8 @@ bundle exec pod binary prebuild --config=Test
 
 - `disable_dsym` (default: `false`): Disable dSYM generation when prebuilding frameworks.
 
+- `still_download_sources` (default: `false`, can be a boolean or an array): By default, we don't download sources of prebuilt pods during CocoaPods installation. However, some pods still need some auxiliary files such as `FirebaseCrashlytics`. This option allows keeping the behavior of downloading sources of prebuilt pods.
+
 - `save_cache_validation_to` (default: `nil`): The path to save cache validation (missed/hit). Do nothing if not specified
 
 - `validate_prebuilt_settings` (default: `nil`): Validate build settings of the prebuilt frameworks. A framework that has incompatible build settings will be treated as a cache miss. If this option is not specified, only versions of the prebuilt pods are used to check for cache hit/miss. Below is a sample build settings validation:

--- a/lib/cocoapods-binary-cache/pod-binary/integration/patch/source_installation.rb
+++ b/lib/cocoapods-binary-cache/pod-binary/integration/patch/source_installation.rb
@@ -3,17 +3,31 @@ require_relative "../source_installer"
 module Pod
   class Installer
     # Override the download step to skip download and prepare file in target folder
-    define_method(:install_source_of_pod) do |pod_name|
-      pod_installer = create_pod_installer(pod_name)
-      # Injected code
-      # ------------------------------------------
-      if should_integrate_prebuilt_pod?(pod_name)
-        pod_installer.install_for_prebuild!(sandbox)
+    alias original_create_pod_installer create_pod_installer
+    def create_pod_installer(name)
+      if should_integrate_prebuilt_pod?(name)
+        create_prebuilt_source_installer(name)
       else
-        pod_installer.install!
+        create_normal_source_installer(name)
       end
-      # ------------------------------------------
-      @installed_specs.concat(pod_installer.specs_by_platform.values.flatten.uniq)
+    end
+
+    private
+
+    def create_normal_source_installer(name)
+      original_create_pod_installer(name)
+    end
+
+    def create_prebuilt_source_installer(name)
+      source_installer = PodSourceInstaller.new(sandbox, podfile, specs_for_pod(name))
+      pod_installer = PrebuiltSourceInstaller.new(
+        sandbox,
+        podfile,
+        specs_for_pod(name),
+        source_installer: source_installer
+      )
+      pod_installers << pod_installer
+      pod_installer
     end
 
     def should_integrate_prebuilt_pod?(name)

--- a/lib/command/config.rb
+++ b/lib/command/config.rb
@@ -103,6 +103,11 @@ module PodPrebuild
       @dsl_config[:disable_dsym]
     end
 
+    def still_download_sources?(name)
+      option = @dsl_config[:still_download_sources]
+      option.is_a?(Array) ? option.include?(name) : option
+    end
+
     def dont_remove_source_code?
       @dsl_config[:dont_remove_source_code]
     end
@@ -162,6 +167,7 @@ module PodPrebuild
         :bitcode_enabled,
         :device_build_enabled,
         :disable_dsym,
+        :still_download_sources,
         :dont_remove_source_code,
         :build_args,
         :save_cache_validation_to,

--- a/spec/integration/installer_spec.rb
+++ b/spec/integration/installer_spec.rb
@@ -1,68 +1,54 @@
 require "cocoapods-binary-cache/pod-binary/integration/patch/source_installation"
 
 describe "Pod::Installer" do
-  describe "#install_source_of_pod" do
+  describe "#create_pod_installer" do
     let(:prebuilt_pod_names_cache_missed) { ["A"] }
     let(:prebuilt_pod_names_cache_hit) { ["B"] }
     let(:prebuilt_pod_names) { prebuilt_pod_names_cache_missed + prebuilt_pod_names_cache_hit }
     let(:non_prebuilt_pod_names) { ["X"] }
     let(:pod_names) { prebuilt_pod_names + non_prebuilt_pod_names }
-    let(:pod_lockfile) do
-      gen_lockfile(pods: pod_names.map { |name| [name, { :version => "0.0.5" }] }.to_h)
-    end
-    let(:podfile) do
-      prebuilt_pod_names_ = prebuilt_pod_names
-      non_prebuilt_pod_names_ = non_prebuilt_pod_names
-      Pod::Podfile.new do
-        source "https://cdn.cocoapods.org/"
-        target "Demo" do
-          prebuilt_pod_names_.each { |name| pod name, "0.0.5", :binary => true }
-          non_prebuilt_pod_names_.each { |name| pod name, "0.0.5" }
-        end
-      end
-    end
     let(:tmp_dir) { create_tempdir }
     let(:sandbox) { Pod::Sandbox.new(tmp_dir) }
 
     before do
-      cache_validation = PodPrebuild::CacheValidationResult.new(
-        prebuilt_pod_names_cache_missed.map { |name| [name, "missing"] }.to_h,
-        prebuilt_pod_names_cache_hit.to_set
+      allow(PodPrebuild.state).to receive(:cache_validation).and_return(
+        PodPrebuild::CacheValidationResult.new(
+          prebuilt_pod_names_cache_missed.map { |name| [name, "missing"] }.to_h,
+          prebuilt_pod_names_cache_hit.to_set
+        )
       )
-      allow(PodPrebuild.state).to receive(:cache_validation).and_return(cache_validation)
-      @source_installer = Object.new
-      @installer = Pod::Installer.new(sandbox, podfile, pod_lockfile)
-      @installer.instance_variable_set(:@installed_specs, [])
-      allow(@installer).to receive(:create_pod_installer).and_return(@source_installer)
-      allow(@source_installer).to receive_message_chain(:specs_by_platform, :values).and_return([])
+
+      @installer = Pod::Installer.new(sandbox, Pod::Podfile.new, nil)
+      allow(@installer).to receive(:create_prebuilt_source_installer).and_return("prebuilt")
+      allow(@installer).to receive(:create_normal_source_installer).and_return("normal")
     end
 
     after do
       FileUtils.remove_entry tmp_dir
     end
 
+    def expect_installed_as(type, pods)
+      pods.each { |name| expect(@installer.create_pod_installer(name)).to eq(type) }
+    end
+
+    def expect_installed_as_normal(pods)
+      expect_installed_as("normal", pods)
+    end
+
+    def expect_installed_as_prebuilt(pods)
+      expect_installed_as("prebuilt", pods)
+    end
+
     it "installs source of non prebuilt pods as normal" do
-      non_prebuilt_pod_names.each do |name|
-        expect(@source_installer).to receive(:install!)
-        expect(@source_installer).not_to receive(:install_for_prebuild!)
-        @installer.send(:install_source_of_pod, name)
-      end
+      expect_installed_as_normal(non_prebuilt_pod_names)
     end
 
     it "installs source the missed pod as normal" do
-      prebuilt_pod_names_cache_missed.each do |name|
-        expect(@source_installer).to receive(:install!)
-        expect(@source_installer).not_to receive(:install_for_prebuild!)
-        @installer.send(:install_source_of_pod, name)
-      end
+      expect_installed_as_normal(prebuilt_pod_names_cache_missed)
     end
 
     it "installs source of prebuilt pods with cache hit differently" do
-      prebuilt_pod_names_cache_hit.each do |name|
-        expect(@source_installer).to receive(:install_for_prebuild!)
-        expect(@source_installer).not_to receive(:install!)
-        @installer.send(:install_source_of_pod, name)
-      end
+      expect_installed_as_prebuilt(prebuilt_pod_names_cache_hit)
     end
 
     context "is prebuild job" do
@@ -70,11 +56,7 @@ describe "Pod::Installer" do
         allow(PodPrebuild.config).to receive(:prebuild_job?).and_return(true)
       end
       it "installs source of all prebuilt pods differently" do
-        prebuilt_pod_names.each do |name|
-          expect(@source_installer).to receive(:install_for_prebuild!)
-          expect(@source_installer).not_to receive(:install!)
-          @installer.send(:install_source_of_pod, name)
-        end
+        expect_installed_as_prebuilt(prebuilt_pod_names)
       end
 
       context "targets were specified in CLI" do
@@ -83,11 +65,7 @@ describe "Pod::Installer" do
           allow(PodPrebuild.config).to receive(:targets_to_prebuild_from_cli).and_return(targets_to_prebuild_from_cli)
         end
         it "installs specified targets & cache hit as prebuilt" do
-          (prebuilt_pod_names_cache_hit + targets_to_prebuild_from_cli).each do |name|
-            expect(@source_installer).to receive(:install_for_prebuild!)
-            expect(@source_installer).not_to receive(:install!)
-            @installer.send(:install_source_of_pod, name)
-          end
+          expect_installed_as_prebuilt(prebuilt_pod_names_cache_hit + targets_to_prebuild_from_cli)
         end
       end
     end

--- a/spec/integration/prebuilt_source_installer_spec.rb
+++ b/spec/integration/prebuilt_source_installer_spec.rb
@@ -1,0 +1,38 @@
+require "cocoapods-binary-cache/pod-binary/integration/patch/source_installation"
+
+describe "Pod::Installer::PrebuiltSourceInstaller" do
+  describe "#install!" do
+    let(:podfile) { Pod::Podfile.new }
+    let(:tmp_dir) { create_tempdir }
+    let(:sandbox) { Pod::Sandbox.new(tmp_dir) }
+    let(:name) { "A" }
+    before do
+      @source_installer = Pod::Installer::PodSourceInstaller.new(sandbox, podfile, [])
+      @installer = Pod::Installer::PrebuiltSourceInstaller.new(
+        sandbox,
+        podfile,
+        [],
+        source_installer: @source_installer
+      )
+      allow(@installer).to receive(:name).and_return(name)
+      allow(@installer).to receive(:install_prebuilt_framework!)
+    end
+
+    after do
+      FileUtils.remove_entry tmp_dir
+    end
+
+    describe "download sources" do
+      it "does not downloads sources by default" do
+        expect(@source_installer).not_to receive(:install!)
+        @installer.install!
+      end
+
+      it "downloads sources if specified in DSL" do
+        allow(PodPrebuild.config).to receive(:still_download_sources?).with(name).and_return(true)
+        expect(@source_installer).to receive(:install!)
+        @installer.install!
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is to fix https://github.com/grab/cocoapods-binary-cache/issues/30

By default, we have the hook to avoid downloading source codes of prebuilt frameworks.
However, some pods still need some auxiliary files such as FirebaseCrashlytics, and it's still useful to perform the download.

This PR provides an option to keep the behavior of the downloading source. Usage:
```rb
config_cocoapods_binary_cache(
  still_download_sources: true
)
```
```rb
config_cocoapods_binary_cache(
  still_download_sources: ["FirebaseCrashlytics"]
)
```