### PR TITLE
chore(*): handle failures in git commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## 0.1.9
+## master (0.1.9)
 ### Enhancements
 - Provide an option to keep sources downloading behavior, useful for maintaining the `preserve_paths` of the podspecs.
 
 ### Bug fixes
-None
+- Handle git failures properly (throwing errors if any).
 
 ## 0.1.8
 ### Enhancements

--- a/lib/command/executor/base.rb
+++ b/lib/command/executor/base.rb
@@ -17,7 +17,8 @@ module PodPrebuild
       comps << cmd
       comps << "&> /dev/null" if options[:ignore_output]
       comps << "|| true" if options[:can_fail]
-      `#{comps.join(" ")}`
+      cmd = comps.join(" ")
+      raise "Fail to run command '#{cmd}'" unless system(cmd)
     end
 
     def git_clone(cmd, options = {})


### PR DESCRIPTION
Handle failures in git commands.

Previously, there were some git commands that failed to run but they didn't throw errors. Running subsequent steps would cause errors and some confusion about the root cause might be misleading as a result.