### PR TITLE
Added 'fetch_repo_branch_before_preinstall' which takes the branch name of the default repo and fetches it before installing from prebuilt

### DIFF
--- a/lib/cocoapods-binary-cache/hooks/pre_install.rb
+++ b/lib/cocoapods-binary-cache/hooks/pre_install.rb
@@ -16,6 +16,11 @@ module PodPrebuild
     def run
       return if @installer_context.sandbox.is_a?(Pod::PrebuildSandbox)
 
+      if PodPrebuild.config.fetch_repo_branch_before_preinstall
+        log_section "🚀  Fetching repo #{PodPrebuild.config.fetch_repo_branch_before_preinstall}"
+        fetch_repo_branch_before_preinstall
+      end
+
       log_section "🚀  Prebuild frameworks"
       ensure_valid_podfile
       save_installation_states
@@ -85,6 +90,17 @@ module PodPrebuild
       @cache_validation.update_to(path_to_save_cache_validation) unless path_to_save_cache_validation.nil?
       cache_validation.print_summary
       PodPrebuild.state.update(:cache_validation => cache_validation)
+    end
+
+    def fetch_repo_branch_before_preinstall
+      fetcher = PodPrebuild::CacheFetcher.new(
+        config: PodPrebuild.config,
+        cache_branch: PodPrebuild.config.fetch_repo_branch_before_preinstall
+      )
+
+      Pod::UI.title("Fetching...") do
+        fetcher.run
+      end
     end
 
     def prebuild!

--- a/lib/command/config.rb
+++ b/lib/command/config.rb
@@ -77,6 +77,10 @@ module PodPrebuild
       Pod::UI.puts message.yellow
     end
 
+    def fetch_repo_branch_before_preinstall
+      @dsl_config[:fetch_repo_branch_before_preinstall]
+    end
+
     def prebuild_config
       @cli_config[:prebuild_config] || @dsl_config[:prebuild_config] || "Debug"
     end
@@ -183,7 +187,8 @@ module PodPrebuild
         :validate_prebuilt_settings,
         :prebuild_code_gen,
         :strict_diagnosis,
-        :silent_build
+        :silent_build,
+        :fetch_repo_branch_before_preinstall
       ]
     end
 


### PR DESCRIPTION

<!--
  Thanks for contributing to our project.
  To make the issue more descriptive and easier to categorize, please prefix the issue title with `feature request:`.
  Following are some good examples:
    - `feature request: allow running code generation before prebuilding`
    - `feature request: allow customization for fetcher/pusher`
-->

### Checklist
<!-- Kindly check the following items by replacing `[ ]` with `[x]` -->
- [ X] I've read the [Contribution Guidelines](https://github.com/grab/cocoapods-binary-cache/blob/master/CONTRIBUTING.md)
- [X ] I've run `bundle exec rspec` from the root directory to run my changes against rspec tests
- [ -] I've run `bundle exec rubocop` to check code style => 1 lint because Class has 108/100 max lines

### Description
<!-- Describe your changes here -->
<details><pre>I wanted to be able to fetch a specific repo branch for each pod install to avoid having to change any CI between different projects that don't use this gem

specifying `config_cocoapods_binary_cache { fetch_repo_before_preinstall: "branch_name" }` will be executed before looking for prebuilt cache or prebuilding
</pre></details>
