### PR TITLE
chore(*): excluded archs for Apple Silicon

### DIFF
--- a/integration_tests/Podfile
+++ b/integration_tests/Podfile
@@ -54,6 +54,7 @@ post_install do |installer|
     target.build_configurations.each do |config|
       config.build_settings["SWIFT_SUPPRESS_WARNINGS"] = "YES"
       config.build_settings["GCC_WARN_INHIBIT_ALL_WARNINGS"] = "YES"
+      config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
     end
   end
 end

--- a/integration_tests/PrebuiltPodIntegration.xcodeproj/project.pbxproj
+++ b/integration_tests/PrebuiltPodIntegration.xcodeproj/project.pbxproj
@@ -31,6 +31,13 @@
 /* Begin PBXFileReference section */
 		066F64AEFC43FE8574CEDF97 /* Pods_PrebuiltPodIntegration.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrebuiltPodIntegration.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AEA7E14D0D538678135454A /* Pods-PrebuiltPodIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebuiltPodIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-PrebuiltPodIntegrationTests/Pods-PrebuiltPodIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
+		0CF7C99A25C51341008FB62C /* PrebuiltPodIntegration.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PrebuiltPodIntegration.debug.xcconfig; sourceTree = "<group>"; };
+		0CF7C99B25C51341008FB62C /* common.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = common.debug.xcconfig; sourceTree = "<group>"; };
+		0CF7C99C25C51341008FB62C /* common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = common.xcconfig; sourceTree = "<group>"; };
+		0CF7C99D25C51341008FB62C /* PrebuiltPodIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PrebuiltPodIntegrationTests.debug.xcconfig; sourceTree = "<group>"; };
+		0CF7C99E25C51341008FB62C /* PrebuiltPodIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PrebuiltPodIntegrationTests.release.xcconfig; sourceTree = "<group>"; };
+		0CF7C99F25C51341008FB62C /* common.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = common.release.xcconfig; sourceTree = "<group>"; };
+		0CF7C9A025C51341008FB62C /* PrebuiltPodIntegration.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = PrebuiltPodIntegration.release.xcconfig; sourceTree = "<group>"; };
 		1AB72549A72ABB5895E3DAE3 /* Pods-PrebuiltPodIntegration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebuiltPodIntegration.release.xcconfig"; path = "Target Support Files/Pods-PrebuiltPodIntegration/Pods-PrebuiltPodIntegration.release.xcconfig"; sourceTree = "<group>"; };
 		8DE635E1E3F113131056C5F4 /* Pods_PrebuiltPodIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrebuiltPodIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A27074B5437E1BEA124436D0 /* Pods-PrebuiltPodIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebuiltPodIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-PrebuiltPodIntegrationTests/Pods-PrebuiltPodIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -68,6 +75,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0CF7C99925C51341008FB62C /* xcconfigs */ = {
+			isa = PBXGroup;
+			children = (
+				0CF7C99B25C51341008FB62C /* common.debug.xcconfig */,
+				0CF7C99F25C51341008FB62C /* common.release.xcconfig */,
+				0CF7C99C25C51341008FB62C /* common.xcconfig */,
+				0CF7C99A25C51341008FB62C /* PrebuiltPodIntegration.debug.xcconfig */,
+				0CF7C9A025C51341008FB62C /* PrebuiltPodIntegration.release.xcconfig */,
+				0CF7C99D25C51341008FB62C /* PrebuiltPodIntegrationTests.debug.xcconfig */,
+				0CF7C99E25C51341008FB62C /* PrebuiltPodIntegrationTests.release.xcconfig */,
+			);
+			path = xcconfigs;
+			sourceTree = "<group>";
+		};
 		1B90CB73E9113917565945DD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -90,6 +111,7 @@
 		C0E6F353246921C200D89D3A = {
 			isa = PBXGroup;
 			children = (
+				0CF7C99925C51341008FB62C /* xcconfigs */,
 				C0E6F35E246921C200D89D3A /* PrebuiltPodIntegration */,
 				C0E6F375246921C300D89D3A /* PrebuiltPodIntegrationTests */,
 				C0E6F35D246921C200D89D3A /* Products */,
@@ -459,7 +481,7 @@
 		};
 		C0E6F37C246921C300D89D3A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C9025C5993632286107608C8 /* Pods-PrebuiltPodIntegration.debug.xcconfig */;
+			baseConfigurationReference = 0CF7C99A25C51341008FB62C /* PrebuiltPodIntegration.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -480,7 +502,7 @@
 		};
 		C0E6F37D246921C300D89D3A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1AB72549A72ABB5895E3DAE3 /* Pods-PrebuiltPodIntegration.release.xcconfig */;
+			baseConfigurationReference = 0CF7C9A025C51341008FB62C /* PrebuiltPodIntegration.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -501,7 +523,7 @@
 		};
 		C0E6F37F246921C300D89D3A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A27074B5437E1BEA124436D0 /* Pods-PrebuiltPodIntegrationTests.debug.xcconfig */;
+			baseConfigurationReference = 0CF7C99D25C51341008FB62C /* PrebuiltPodIntegrationTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -523,7 +545,7 @@
 		};
 		C0E6F380246921C300D89D3A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0AEA7E14D0D538678135454A /* Pods-PrebuiltPodIntegrationTests.release.xcconfig */;
+			baseConfigurationReference = 0CF7C99E25C51341008FB62C /* PrebuiltPodIntegrationTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";

--- a/integration_tests/xcconfigs/PrebuiltPodIntegration.debug.xcconfig
+++ b/integration_tests/xcconfigs/PrebuiltPodIntegration.debug.xcconfig
@@ -1,0 +1,2 @@
+#include "common.debug.xcconfig"
+#include "../Pods/Target Support Files/Pods-PrebuiltPodIntegration/Pods-PrebuiltPodIntegration.debug.xcconfig"

--- a/integration_tests/xcconfigs/PrebuiltPodIntegration.release.xcconfig
+++ b/integration_tests/xcconfigs/PrebuiltPodIntegration.release.xcconfig
@@ -1,0 +1,2 @@
+#include "common.release.xcconfig"
+#include "../Pods/Target Support Files/Pods-PrebuiltPodIntegration/Pods-PrebuiltPodIntegration.release.xcconfig"

--- a/integration_tests/xcconfigs/PrebuiltPodIntegrationTests.debug.xcconfig
+++ b/integration_tests/xcconfigs/PrebuiltPodIntegrationTests.debug.xcconfig
@@ -1,0 +1,1 @@
+#include "../Pods/Target Support Files/Pods-PrebuiltPodIntegrationTests/Pods-PrebuiltPodIntegrationTests.debug.xcconfig"

--- a/integration_tests/xcconfigs/PrebuiltPodIntegrationTests.release.xcconfig
+++ b/integration_tests/xcconfigs/PrebuiltPodIntegrationTests.release.xcconfig
@@ -1,0 +1,2 @@
+#include "common.release.xcconfig"
+#include "../Pods/Target Support Files/Pods-PrebuiltPodIntegrationTests/Pods-PrebuiltPodIntegrationTests.release.xcconfig"

--- a/integration_tests/xcconfigs/common.debug.xcconfig
+++ b/integration_tests/xcconfigs/common.debug.xcconfig
@@ -1,0 +1,1 @@
+#include "common.xcconfig"

--- a/integration_tests/xcconfigs/common.release.xcconfig
+++ b/integration_tests/xcconfigs/common.release.xcconfig
@@ -1,0 +1,1 @@
+#include "common.xcconfig"

--- a/integration_tests/xcconfigs/common.xcconfig
+++ b/integration_tests/xcconfigs/common.xcconfig
@@ -1,0 +1,4 @@
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/grab/cocoapods-binary-cache/blob/master/CONTRIBUTING.md)
- [x] I've run `bundle exec rspec` from the root directory to run my changes against rspec tests
- [x] I've run `bundle exec rubocop` to check code style

### Description
Update `EXCLUDED_ARCHS` to make the integration tests project works on Apple Silicon

Note: I haven't updated the `PodBinaryCacheExample` project as it's currently not under active maintenance and gonna change soon.