### PR TITLE
Fix "readlink" Run on Paths That Contain Spaces

### DIFF
--- a/lib/cocoapods-binary-cache/pod-binary/integration/patch/embed_framework_script.rb
+++ b/lib/cocoapods-binary-cache/pod-binary/integration/patch/embed_framework_script.rb
@@ -17,7 +17,7 @@ module Pod
           # If the path isn't an absolute path, we add a realtive prefix.
           old_read_link=`which readlink`
           readlink () {
-            path=`$old_read_link $1`;
+            path=`$old_read_link "$1"`;
             if [ $(echo "$path" | cut -c 1-1) = '/' ]; then
               echo $path;
             else


### PR DESCRIPTION
### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/grab/cocoapods-binary-cache/blob/master/CONTRIBUTING.md)
- [ ] I've run `bundle exec rspec` from the root directory to run my changes against rspec tests
- [ ] I've run `bundle exec rubocop` to check code style

I honestly haven't even cloned the repo, this is a #trivial fix.

### Description

Resolves #49
This PR is an equivalent to https://github.com/leavez/cocoapods-binary/pull/107, since this code uses `cocoapods-binary` internally.

This issue has also been reported https://github.com/CocoaPods/CocoaPods/issues/10298 (although it's not related to CocoaPods, but cocoapods-binary only).