### PR TITLE
Escape the configuration name in commands

### DIFF
--- a/lib/cocoapods-binary-cache/pod-rome/xcodebuild_command.rb
+++ b/lib/cocoapods-binary-cache/pod-rome/xcodebuild_command.rb
@@ -102,16 +102,16 @@ module PodPrebuild
       # for each sdk, the order of params must be -framework then -debug-symbols
       # to prevent duplicated file error when copying dSYMs
       sdks.each do |sdk|
-        cmd << "-framework" << framework_path_of(target, sdk)
+        cmd << "-framework" << framework_path_of(target, sdk).shellescape
 
         unless disable_dsym?
           dsyms = dsym_paths_of(target, sdk)
-          cmd += dsyms.map { |dsym| "-debug-symbols #{dsym}" }
+          cmd += dsyms.map { |dsym| "-debug-symbols #{dsym.shellescape}" }
         end
 
         if bitcode_enabled?
           bcsymbolmaps = bcsymbolmap_paths_of(target, sdk)
-          cmd += bcsymbolmaps.map { |bcsymbolmap| "-debug-symbols #{bcsymbolmap}" }
+          cmd += bcsymbolmaps.map { |bcsymbolmap| "-debug-symbols #{bcsymbolmap.shellescape}" }
         end
       end
 
@@ -181,7 +181,7 @@ module PodPrebuild
     def create_fat_binary(options)
       cmd = ["lipo", " -create"]
       cmd << "-output" << options[:output]
-      cmd << options[:simulator] << options[:device]
+      cmd << options[:simulator].shellescape << options[:device].shellescape
       `#{cmd.join(" ")}`
     end
 

--- a/lib/cocoapods-binary-cache/pod-rome/xcodebuild_raw.rb
+++ b/lib/cocoapods-binary-cache/pod-rome/xcodebuild_raw.rb
@@ -21,7 +21,7 @@ module PodPrebuild
       cmd = ["xcodebuild"]
       cmd << "-project" << options[:sandbox].project_path.realdirpath.shellescape
       targets.each { |target| cmd << "-target" << target }
-      cmd << "-configuration" << options[:configuration]
+      cmd << "-configuration" << options[:configuration].shellescape
       cmd << "-sdk" << sdk
       if DESTINATION_OF_SDK.key?(sdk)
         cmd << "-destination" << DESTINATION_OF_SDK[sdk]


### PR DESCRIPTION
<!--
  Thanks for contributing to our project.
  To make the issue more descriptive and easier to categorize, please prefix the issue title with `feature request:`.
  Following are some good examples:
    - `feature request: allow running code generation before prebuilding`
    - `feature request: allow customization for fetcher/pusher`
-->

### Checklist
<!-- Kindly check the following items by replacing `[ ]` with `[x]` -->
- [x] I've read the [Contribution Guidelines](https://github.com/grab/cocoapods-binary-cache/blob/master/CONTRIBUTING.md)
- [x] I've run `bundle exec rspec` from the root directory to run my changes against rspec tests
- [x] I've run `bundle exec rubocop` to check code style
  (There's one offense in code I didn't change)

### Description
I had to make a couple of changes to get a configuration name with a space ("App Store") to work with the tool. The configuration name (and values derived from that) were not properly escaped when building commands to run.
