### PR TITLE
Support diversified remote cache with hash value(like PODFILE CHECKSUM in Podfile.lock)

### DIFF
--- a/lib/command/executor/fetcher.rb
+++ b/lib/command/executor/fetcher.rb
@@ -37,7 +37,7 @@ module PodPrebuild
     def fetch_remote_cache(repo, branch, dest_dir)
       Pod::UI.puts "Fetching cache from #{repo} (branch: #{branch})".green
       if Dir.exist?(dest_dir + "/.git")
-        git("fetch origin #{branch}")
+        git("fetch --depth 10 origin", can_fail: true)
         git("checkout -f FETCH_HEAD", ignore_output: true)
         git("branch -D #{branch}", ignore_output: true, can_fail: true)
         git("checkout -b #{branch}")

--- a/lib/command/executor/fetcher.rb
+++ b/lib/command/executor/fetcher.rb
@@ -37,13 +37,22 @@ module PodPrebuild
     def fetch_remote_cache(repo, branch, dest_dir)
       Pod::UI.puts "Fetching cache from #{repo} (branch: #{branch})".green
       if Dir.exist?(dest_dir + "/.git")
-        git("fetch --depth 10 origin", can_fail: true)
+        begin
+          git("fetch origin #{branch}")
+        rescue
+          git("fetch --depth 10 origin", can_fail: true)
+        end
         git("checkout -f FETCH_HEAD", ignore_output: true)
         git("branch -D #{branch}", ignore_output: true, can_fail: true)
         git("checkout -b #{branch}")
       else
         FileUtils.rm_rf(dest_dir)
-        git_clone("--depth=1 --branch=#{branch} #{repo} #{dest_dir}")
+        begin
+          git_clone("--depth=1 --branch=#{branch} #{repo} #{dest_dir}")
+        rescue
+          git_clone("--depth=1 #{repo} #{dest_dir}")
+          git("checkout -b #{branch}")
+        end
       end
     end
 

--- a/lib/command/executor/pusher.rb
+++ b/lib/command/executor/pusher.rb
@@ -28,7 +28,7 @@ module PodPrebuild
     def commit_and_push_cache
       commit_message = "Update prebuilt cache"
       git("add .")
-      git("commit -m '#{commit_message}'")
+      git("commit -m '#{commit_message}'", can_fail: true)
       git("push origin #{@cache_branch}")
     end
   end

--- a/lib/command/executor/pusher.rb
+++ b/lib/command/executor/pusher.rb
@@ -14,6 +14,7 @@ module PodPrebuild
         if @config.local_cache?
           print_message_for_local_cache
         else
+          checkout_if_needed
           commit_and_push_cache
         end
       end
@@ -23,6 +24,12 @@ module PodPrebuild
 
     def print_message_for_local_cache
       Pod::UI.puts "Skip pushing cache as you're using local cache".yellow
+    end
+
+    def checkout_if_needed
+      begin
+        git("checkout -b #{@cache_branch}", ignore_output: true, can_fail: true)
+      end
     end
 
     def commit_and_push_cache


### PR DESCRIPTION
<!--
  Thanks for contributing to our project.
  To make the issue more descriptive and easier to categorize, please prefix the issue title with `feature request:`.
  Following are some good examples:
    - `feature request: allow running code generation before prebuilding`
    - `feature request: allow customization for fetcher/pusher`
-->

### Checklist
<!-- Kindly check the following items by replacing `[ ]` with `[x]` -->
- [x] I've read the [Contribution Guidelines](https://github.com/grab/cocoapods-binary-cache/blob/master/CONTRIBUTING.md)
- [x] I've run `bundle exec rspec` from the root directory to run my changes against rspec tests
- [x] I've run `bundle exec rubocop` to check code style

### Description

(Related Issue : https://github.com/grab/cocoapods-binary-cache/issues/46)

Remote cache is very useful to sync pods among developer machines & build machines, but there is a problem when we needs various cache. 

Swift versions can be various(like 5.3.1 & 5.4), Pod composition or prebuild setup can be various between master and other branches. That's why we needs diversified remote caches for seamless adoption of this library for multi environment and machines.

`actions/cache` in `GitHub Actions` support this feature with `key` like below and it's useful.


```yaml
- name: Cache Ruby Dependencies
  uses: actions/cache@v2.1.3
  id: ruby-bundle-cache-step
  with:
    path: ruby-bundle-cache
    key: ${{ env.machine_name }}-${{ env.ruby_version }}-ruby-bundle-cache-${{ hashFiles('Gemfile.lock') }}
```

With this change, user programmers can cache specific state with composited key with hash value like `PODFILE CHECKSUM` in `Podfile.lock` which is used for remote branch name like below:

```makefile
# Makefile

# Mostly for build machine
project:
  make xcodegen_generate
  make pod_install

# For daily development for developer
project_fast:
  make xcodegen_generate
  bundle exec pod install

...

podfile_lock_checksum:
  @echo `grep "PODFILE CHECKSUM: " Podfile.lock | awk '{print $$3}'`

# Need to execute on Podfile changes
# Branch name would be 'swift5.4-PODFILE_CHECKSUM'
pod_install:
  bundle exec pod binary prebuild "swift$$(make swift_version)-$$(make podfile_lock_checksum)" --no-fetch # Previous CHECKSUM
  bundle exec pod binary fetch "swift$$(make swift_version)-$$(make podfile_lock_checksum)" # Needs to create new branch if needed (I found `pod binary fetch` handle this)
  bundle exec pod binary push "swift$$(make swift_version)-$$(make podfile_lock_checksum)" # with new CHECKSUM if it is changed after prebuild

...
```

# Changes

- Can clone with branch name which doesn't exist on remote origin
- Can fetch with branch name which doesn't exist on remote origin
- Can push cache with new branch (composited name with swift version or changed CHECKSUM)
- Create new branch before commit & push when the new cache will be pushed