### PR TITLE
Fix: Add mutex to prevent Attribute not found error when threading unzips

### DIFF
--- a/lib/command/executor/fetcher.rb
+++ b/lib/command/executor/fetcher.rb
@@ -9,6 +9,7 @@ module PodPrebuild
     def initialize(options)
       super(options)
       @cache_branch = options[:cache_branch]
+      @unpack_mutex = Mutex.new
     end
 
     def run
@@ -60,7 +61,9 @@ module PodPrebuild
       end
       zip_paths = Dir[@config.generated_frameworks_dir(in_cache: true) + "/*.zip"]
       Parallel.each(zip_paths, in_threads: 8) do |path|
-        ZipUtils.unzip(path, to_dir: @config.generated_frameworks_dir)
+        @unpack_mutex.synchronize do
+         ZipUtils.unzip(path, to_dir: @config.generated_frameworks_dir)
+        end
       end
     end
   end

--- a/lib/command/helper/zip.rb
+++ b/lib/command/helper/zip.rb
@@ -12,7 +12,7 @@ module PodPrebuild
 
     def self.unzip(path, to_dir: nil)
       cmd = []
-      cmd << "unzip -nq" << path
+      cmd << "unzip -oq" << path
       cmd << "-d" << to_dir unless to_dir.nil?
       `#{cmd.join(" ")}`
     end


### PR DESCRIPTION
<!--
  Thanks for contributing to our project.
  To make the issue more descriptive and easier to categorize, please prefix the issue title with `feature request:`.
  Following are some good examples:
    - `feature request: allow running code generation before prebuilding`
    - `feature request: allow customization for fetcher/pusher`
-->

### Checklist
<!-- Kindly check the following items by replacing `[ ]` with `[x]` -->
- [x] I've read the [Contribution Guidelines](https://github.com/grab/cocoapods-binary-cache/blob/master/CONTRIBUTING.md)
- [x] I've run `bundle exec rspec` from the root directory to run my changes against rspec tests
- [x] I've run `bundle exec rubocop` to check code style

### Description
<!-- Describe your changes here -->
This change fixes an issue occurring when threading multiple zips in parallel - the cache directory couldn't be created and errored with:

```
checkdir:  cannot create extraction directory: _Prebuild/GeneratedFrameworks
           Attribute not found
```

Digging deeper into this it seems Carthage had a similar issue which was resolved this way:

https://github.com/kayak/carthage_remote_cache/issues/1
https://github.com/kayak/carthage_remote_cache/commit/df014b602f832e8156bf1a9976c0d9b053d01956

The unzip command seems to not be thread safe.